### PR TITLE
support rtl orientation

### DIFF
--- a/equalizer/src/main/res/layout/dialog_fragment_equalizer.xml
+++ b/equalizer/src/main/res/layout/dialog_fragment_equalizer.xml
@@ -62,7 +62,9 @@
             android:layout_height="0dp"
             android:layout_marginLeft="9dp"
             android:layout_marginRight="9dp"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:layoutDirection="ltr"
+            >
 
             <View
                 android:layout_width="50dp"

--- a/equalizer/src/main/res/layout/dialog_fragment_equalizer.xml
+++ b/equalizer/src/main/res/layout/dialog_fragment_equalizer.xml
@@ -96,7 +96,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar1"
@@ -125,7 +127,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar2"
@@ -154,7 +158,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar3"
@@ -183,7 +189,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar4"
@@ -212,7 +220,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar5"

--- a/equalizer/src/main/res/layout/fragment_equalizer.xml
+++ b/equalizer/src/main/res/layout/fragment_equalizer.xml
@@ -68,7 +68,9 @@
             android:layout_marginLeft="9dp"
             android:layout_marginRight="9dp"
             android:layout_weight="1"
-            android:background="#33000000">
+            android:background="#33000000"
+            android:layoutDirection="ltr"
+            >
 
             <View
                 android:id="@+id/showcase_view_equalizer"

--- a/equalizer/src/main/res/layout/fragment_equalizer.xml
+++ b/equalizer/src/main/res/layout/fragment_equalizer.xml
@@ -113,7 +113,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar1"
@@ -142,7 +144,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar2"
@@ -171,7 +175,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar3"
@@ -200,7 +206,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar4"
@@ -229,7 +237,9 @@
                 <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
-                    android:layout_weight="8">
+                    android:layout_weight="8"
+                    android:layoutDirection="ltr"
+                    >
 
                     <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBar
                         android:id="@+id/seekBar5"


### PR DESCRIPTION
To make seekBars visibles in rtl orientation, I added attribut android:layoutDirection=ltr to each tag  <com.h6ah4i.android.widget.verticalseekbar.VerticalSeekBarWrapper 